### PR TITLE
Add pluggable retrievers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # RAG-Normas
+
+Exemplo simples de uso de *retrievers* em um fluxo RAG. 
+
+Este repositório inclui uma implementação básica de dois mecanismos de
+recuperação de documentos: **TF‑IDF** e **BM25**. A escolha do tipo de retriever
+é feita através de um único parâmetro.
+
+## Como utilizar
+
+1. Instale as dependências (somente `scikit-learn` é necessária):
+
+```bash
+pip install scikit-learn
+```
+
+2. Execute o exemplo passando o tipo de retriever desejado (`tfidf` ou
+   `bm25`):
+
+```bash
+python example.py bm25
+```
+
+Isso irá imprimir na tela os documentos recuperados e a pontuação
+atribuída por cada algoritmo.

--- a/example.py
+++ b/example.py
@@ -1,0 +1,24 @@
+"""Example usage for the retrievers module."""
+
+from retrievers import get_retriever
+
+docs = [
+    "o rato roeu a roupa do rei de roma",
+    "a raposa marrom pula sobre o cachorro preguiçoso",
+    "um pequeno passo para o homem, um grande salto para a humanidade",
+]
+
+
+def run_example(kind: str = "tfidf"):  # pragma: no cover
+    retriever = get_retriever(kind, docs)
+    res = retriever.retrieve("passo homem", top_k=2)
+    for doc, score in res:
+        print(f"{score:.4f}: {doc}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    kind = sys.argv[1] if len(sys.argv) > 1 else "tfidf"
+    run_example(kind)
+

--- a/retrievers.py
+++ b/retrievers.py
@@ -1,0 +1,95 @@
+class BaseRetriever:
+    """Base retriever interface."""
+
+    def __init__(self, documents):
+        self.documents = documents
+
+    def retrieve(self, query, top_k=3):
+        raise NotImplementedError
+
+
+class TFIDFRetriever(BaseRetriever):
+    """Simple TF-IDF retriever using scikit-learn."""
+
+    def __init__(self, documents):
+        super().__init__(documents)
+        from sklearn.feature_extraction.text import TfidfVectorizer
+
+        self.vectorizer = TfidfVectorizer()
+        self.document_matrix = self.vectorizer.fit_transform(documents)
+
+    def retrieve(self, query, top_k=3):
+        query_vec = self.vectorizer.transform([query])
+        scores = (self.document_matrix @ query_vec.T).toarray().ravel()
+        ranked = scores.argsort()[::-1][:top_k]
+        return [(self.documents[i], float(scores[i])) for i in ranked]
+
+
+class BM25Retriever(BaseRetriever):
+    """Naive BM25 retriever implemented without external deps."""
+
+    def __init__(self, documents, k1=1.5, b=0.75):
+        super().__init__(documents)
+        from collections import Counter, defaultdict
+        import math
+
+        self.k1 = k1
+        self.b = b
+        self.tokenized = [doc.split() for doc in documents]
+        self.n = len(documents)
+        self.avgdl = sum(len(t) for t in self.tokenized) / float(self.n)
+        self.doc_freqs = []
+        df = defaultdict(int)
+        for tokens in self.tokenized:
+            freq = Counter(tokens)
+            self.doc_freqs.append(freq)
+            for token in freq:
+                df[token] += 1
+        self.idf = {w: math.log(1 + (self.n - f + 0.5) / (f + 0.5)) for w, f in df.items()}
+
+    def _score(self, query_tokens, idx):
+        import math
+
+        score = 0.0
+        freq = self.doc_freqs[idx]
+        dl = len(self.tokenized[idx])
+        for token in query_tokens:
+            if token in freq:
+                idf = self.idf.get(token, 0)
+                tf = freq[token]
+                denom = tf + self.k1 * (1 - self.b + self.b * dl / self.avgdl)
+                score += idf * (tf * (self.k1 + 1)) / denom
+        return score
+
+    def retrieve(self, query, top_k=3):
+        tokens = query.split()
+        scores = [self._score(tokens, idx) for idx in range(self.n)]
+        ranked = sorted(range(self.n), key=lambda i: scores[i], reverse=True)[:top_k]
+        return [(self.documents[i], float(scores[i])) for i in ranked]
+
+
+def get_retriever(name, documents):
+    """Factory for retrievers.
+
+    Parameters
+    ----------
+    name : str
+        Name of the retriever ("tfidf" or "bm25").
+    documents : list[str]
+        Collection of texts to index.
+    """
+    name = name.lower()
+    if name == "tfidf":
+        return TFIDFRetriever(documents)
+    if name == "bm25":
+        return BM25Retriever(documents)
+    raise ValueError(f"Unknown retriever: {name}")
+
+
+__all__ = [
+    "BaseRetriever",
+    "TFIDFRetriever",
+    "BM25Retriever",
+    "get_retriever",
+]
+


### PR DESCRIPTION
## Summary
- implement `get_retriever` factory with `TFIDFRetriever` and a simple `BM25Retriever`
- provide example script demonstrating how to switch retrievers with a single parameter
- document usage in README

## Testing
- `python example.py tfidf`
- `python example.py bm25`
- `python -m py_compile retrievers.py example.py`


------
https://chatgpt.com/codex/tasks/task_e_684adc06a278832ca33659bdc81f9e9c