### PR TITLE
Implement simple RAG pipeline

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,16 +1,17 @@
 """Exemplo simples de uso do sistema RAG para normas técnicas."""
 
 from ingestion.ingest import ingest_documents
-from retrieval.retriever import search
+from retrieval.retriever import Retriever
 from generation.generate import generate_answer
 
 
 def main() -> None:
-    data_path = "data/normas"
-    ingest_documents(data_path)
+    data_path = "data"
+    documents = ingest_documents(data_path)
+    retriever = Retriever(documents)
 
     query = input("Consulta: ")
-    docs = search(query)
+    docs = retriever.search(query)
     answer = generate_answer(query, docs)
     print(answer)
 

--- a/src/generation/generate.py
+++ b/src/generation/generate.py
@@ -1,8 +1,13 @@
 """Geração de respostas utilizando LLM e conteúdo recuperado."""
 
+from typing import List
 
-def generate_answer(query: str, documents) -> str:
-    """Combina ``query`` e ``documents`` para gerar a resposta final."""
-    # TODO: integrar com modelo de linguagem
+
+def generate_answer(query: str, documents: List[str]) -> str:
+    """Combina ``query`` e ``documents`` para gerar uma resposta simples."""
     print(f"Generating answer for '{query}' with {len(documents)} docs")
-    return "Resposta gerada"
+
+    # Nesta implementação simplificada, apenas concatenamos trechos
+    context = "\n".join(documents)
+    snippet = context[:500]
+    return f"Pergunta: {query}\n\nTrechos:\n{snippet}"

--- a/src/ingestion/ingest.py
+++ b/src/ingestion/ingest.py
@@ -1,12 +1,27 @@
 """Módulos para ingestão de normas técnicas."""
 
 from pathlib import Path
+from typing import List
+
+from pypdf import PdfReader
 
 
-def ingest_documents(data_path: str) -> None:
-    """Processa documentos em ``data_path`` e prepara para indexação."""
+def ingest_documents(data_path: str) -> List[str]:
+    """Processa documentos em ``data_path`` e retorna textos extraídos."""
     path = Path(data_path)
     if not path.exists():
         raise FileNotFoundError(f"Pasta inexistente: {data_path}")
-    # TODO: implementar leitura de arquivos e criação de embeddings
-    print(f"Ingesting documents from {path.resolve()}")
+
+    documents: List[str] = []
+    for pdf_file in path.glob("*.pdf"):
+        reader = PdfReader(str(pdf_file))
+        text = "\n".join(
+            page.extract_text() or "" for page in reader.pages
+        )
+        documents.append(text)
+
+    if not documents:
+        raise ValueError(f"Nenhum PDF encontrado em {data_path}")
+
+    print(f"Ingested {len(documents)} document(s) from {path.resolve()}")
+    return documents

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -1,8 +1,24 @@
 """Mecanismos de busca para as normas técnicas."""
 
+from typing import List
 
-def search(query: str):
-    """Realiza busca no índice e retorna documentos relevantes."""
-    # TODO: implementar busca no vetor store
-    print(f"Searching for '{query}'")
-    return []
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+class Retriever:
+    """Busca documentos relevantes utilizando TF-IDF."""
+
+    def __init__(self, documents: List[str]):
+        # ``stop_words`` aceita apenas ``None`` ou ``'english'`` por padrão.
+        self.vectorizer = TfidfVectorizer()
+        self.doc_vectors = self.vectorizer.fit_transform(documents)
+        self.documents = documents
+
+    def search(self, query: str, top_k: int = 3) -> List[str]:
+        """Retorna ``top_k`` documentos mais relevantes para ``query``."""
+        print(f"Searching for '{query}'")
+        query_vec = self.vectorizer.transform([query])
+        scores = cosine_similarity(query_vec, self.doc_vectors).flatten()
+        ranked = scores.argsort()[::-1]
+        return [self.documents[i] for i in ranked[:top_k]]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from ingestion.ingest import ingest_documents
+
+
+def test_ingest_documents():
+    docs = ingest_documents('data')
+    assert isinstance(docs, list)
+    assert len(docs) > 0

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from ingestion.ingest import ingest_documents
+from retrieval.retriever import Retriever
+
+
+def test_retrieval_search():
+    docs = ingest_documents('data')
+    r = Retriever(docs)
+    results = r.search('tensao')
+    assert isinstance(results, list)
+    assert len(results) > 0


### PR DESCRIPTION
## Summary
- implement document ingestion using `pypdf`
- implement a TF‑IDF based retriever
- build a basic answer generator
- update example `app.py` to wire components
- add ingestion and retrieval tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859963a641c832c85299bf87b040343