### PR TITLE
Add HuggingFace inference integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ RAG-Normas/
 ├── tests/           # Casos de teste
 └── README.md        # Descrição do projeto
 ```
+
+## Hugging Face Inference API
+
+O módulo `src/generation/generate.py` utiliza a Inference API da Hugging Face
+para gerar respostas. Configure as seguintes variáveis de ambiente ao executar
+`src/app.py`:
+
+- `HF_MODEL`: identificador do modelo no Hub (padrão `google/flan-t5-base`)
+- `HF_API_TOKEN`: token de autenticação (opcional para modelos públicos)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pypdf>=3.1
 scikit-learn>=1.2
 pytest>=7.4
+requests>=2.31

--- a/src/generation/generate.py
+++ b/src/generation/generate.py
@@ -1,13 +1,42 @@
 """Geração de respostas utilizando LLM e conteúdo recuperado."""
 
+from __future__ import annotations
+
+import os
 from typing import List
+
+import requests
+
+
+HF_MODEL = os.getenv("HF_MODEL", "google/flan-t5-base")
+HF_API_TOKEN = os.getenv("HF_API_TOKEN")
+
+
+def _hf_inference(prompt: str) -> str:
+    """Realiza chamada à Inference API da Hugging Face."""
+    url = f"https://api-inference.huggingface.co/models/{HF_MODEL}"
+    headers = {"Authorization": f"Bearer {HF_API_TOKEN}"} if HF_API_TOKEN else {}
+    response = requests.post(url, headers=headers, json={"inputs": prompt}, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    if isinstance(data, list) and data and "generated_text" in data[0]:
+        return data[0]["generated_text"]
+    if isinstance(data, dict) and "generated_text" in data:
+        return data["generated_text"]
+    return str(data)
 
 
 def generate_answer(query: str, documents: List[str]) -> str:
-    """Combina ``query`` e ``documents`` para gerar uma resposta simples."""
+    """Combina ``query`` e ``documents`` para gerar uma resposta utilizando a Inference API."""
     print(f"Generating answer for '{query}' with {len(documents)} docs")
 
-    # Nesta implementação simplificada, apenas concatenamos trechos
     context = "\n".join(documents)
-    snippet = context[:500]
-    return f"Pergunta: {query}\n\nTrechos:\n{snippet}"
+    snippet = context[:1000]
+    prompt = f"Pergunta: {query}\n\nContexto:\n{snippet}"
+
+    try:
+        return _hf_inference(prompt)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Hugging Face inference failed: {exc}")
+        return prompt


### PR DESCRIPTION
## Summary
- use Hugging Face Inference API for answer generation
- document new environment variables
- add `requests` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a00eaeb8832cafad199493df6e79