### PR TITLE
Add inference testing notebook

### DIFF
--- a/Inference_Test.ipynb
+++ b/Inference_Test.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d375e872",
+   "metadata": {},
+   "source": [
+    "# Teste de Inferência\n",
+    "Este notebook demonstra como executar o pipeline de RAG para gerar respostas a partir das normas técnicas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20650023",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "\n",
+    "# Adiciona diretório src ao path para permitir imports\n",
+    "sys.path.append(str(Path.cwd() / \"src\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d479e4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ingestion.ingest import ingest_documents\n",
+    "from retrieval.retriever import Retriever\n",
+    "from generation.generate import generate_answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "590f3008",
+   "metadata": {},
+   "source": [
+    "## 1. Ingestão de documentos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0a16d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs = ingest_documents(\"data\")\n",
+    "print(f\"{len(docs)} documento(s) carregado(s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f325a34a",
+   "metadata": {},
+   "source": [
+    "## 2. Criação do buscador"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40f67719",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = Retriever(docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f5985e3",
+   "metadata": {},
+   "source": [
+    "## 3. Consulta e geração de resposta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d899a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"Qual a tensão mínima de isolamento?\"\n",
+    "results = retriever.search(query)\n",
+    "print(\"Documentos recuperados:\", len(results))\n",
+    "answer = generate_answer(query, results)\n",
+    "print(\"Resposta gerada:\n",
+    "\", answer)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `Inference_Test.ipynb` with a small workflow for ingesting docs, searching with TF-IDF and generating an answer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b162aaa0832c9cebe696fb2ff5ff